### PR TITLE
Fix include in MANIFEST.in for README and LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include versioneer.py
 include pokrok/_version.py
-README.md
-LICENSE
+include README.md
+include LICENSE


### PR DESCRIPTION
The `MANIFEST.in` was not properly configured to include the README and LICENSE files.