### PR TITLE
Port from pkg_resources to importlib.resources

### DIFF
--- a/pokrok/__init__.py
+++ b/pokrok/__init__.py
@@ -14,6 +14,10 @@ choose whether or not to use those arguments.
 
 """
 from collections.abc import Sized
+try:
+    import importlib.resources as importlib_resources
+except ImportError:
+    import importlib_resources
 import json
 import math
 import os
@@ -59,9 +63,10 @@ class ProgressFactory:
             else:
                 try:
                     package, path = filename.split(':')
-                    import pkg_resources as pr
-                    if pr.resource_exists(package, path):
-                        config = json.load(pr.resource_stream(package, path))
+                    if importlib_resources.is_resource(package, path):
+                        config = json.loads(
+                            importlib_resources.read_text(package, path)
+                        )
                 except:
                     pass
             if config is None:

--- a/pokrok/plugins/__init__.py
+++ b/pokrok/plugins/__init__.py
@@ -2,9 +2,11 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 import enum
 import importlib
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
 from typing import Iterable, Optional
-
-from pkg_resources import iter_entry_points
 
 
 # ProgressMeter statuses
@@ -29,7 +31,7 @@ class PluginManager:
         # Load the factory classes from the discovered entry points
         plugin_types = dict(
             (entry_point.name, entry_point.load())
-            for entry_point in iter_entry_points(group="pokrok")
+            for entry_point in entry_points(group="pokrok")
         )
 
         # Filter and order if names are provided

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ setup(
     description='Simple API for progress bars using any of several supported libraries',
     license='MIT',
     packages=find_packages(),
+    install_requires=[
+        'importlib-metadata; python_version<"3.8"',
+        'importlib-resources; python_version<"3.7"',
+    ],
     tests_require=['pytest'],  # , 'jinja2', 'pysam'],
     entry_points={
         'pokrok': [


### PR DESCRIPTION
`pkg_resources` is deprecated (see
https://setuptools.pypa.io/en/latest/pkg_resources.html).