### PR TITLE
ci: add PyPI trusted-publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools-scm needs full history + tags
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist and wheel
+        run: uv build
+      - name: Check the distributions
+        run: uvx twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # trusted publishing to PyPI via OIDC (no stored token)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a Release workflow that publishes to PyPI on a version tag (bare X.Y.Z, matching the setuptools-scm tag scheme) via OIDC trusted publishing, so no PyPI token is stored in the repo.

Flow: on a version tag, build with uv, twine-check the dists, then upload with pypa/gh-action-pypi-publish using a 'pypi' environment.

Requires a one-time PyPI-side trusted-publisher config (owner jdidion, repo pokrok, workflow release.yml, environment pypi).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>